### PR TITLE
fix: use jasmine test runner

### DIFF
--- a/packages/jest-config/jest-preset.js
+++ b/packages/jest-config/jest-preset.js
@@ -33,4 +33,5 @@ module.exports = merge.recursive(true, jsWithTs, {
     '^.+\\.ts?$': 'ts-jest'
   },
   // verbose: true,
+  testRunner: "jest-jasmine2",
 });


### PR DESCRIPTION
jest 27's default test runner breaks existing tests, use previous one to avoid breaking tests

see: https://github.com/facebook/jest/issues/11404#issuecomment-839892249